### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @charmed-hpc/terraform-reviewers


### PR DESCRIPTION
Small PR to add a CODEOWNERS file. Set the main reviewer to the Terraform team for now, but ideally as our group grows we will further granularize "who reviews what." Terraform team works for now since the bulk of this repository is focused on Terraform for managing our organization.