### PR TITLE
feat: add `gen-contrib` script for generating CONTRIBUTING.md documents

### DIFF
--- a/scripts/gen-contrib
+++ b/scripts/gen-contrib
@@ -27,6 +27,9 @@ DEFAULT_ORG_CONTRIBUTING_URL = (
     "https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md"
 )
 DEFAULT_MATRIX_URL = "https://matrix.to/#/#hpc:ubuntu.com"
+DEFAULT_GITHUB_DISCUSSIONS_URL = (
+    "https://github.com/orgs/charmed-hpc/discussions/categories/support"
+)
 LICENSES = {
     "agpl-3.0-only": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/AGPL-3.0-only.json",
     "apache-2.0": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/Apache-2.0.json",
@@ -41,14 +44,15 @@ Do you want to contribute to the `${repo}` repository? You've come to the right 
 __Here is how you can get involved.__
 
 Before you start working on your contribution, please familiarize yourself with the [Charmed
-HPC project's contributing guide]. Come back here after you've gone through
-the main contributing guide for specific information on contributing to the
-`${repo}` repository.
+HPC project's contributing guide]. After you've gone through the main contributing guide,
+you can use this guide for specific information on contributing to the `${repo}` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
+or on [GitHub Discussions].
 
 [Charmed HPC project's contributing guide]: ${org_contrib_url}
 [Ubuntu High-Performance Computing Matrix chat]: ${matrix_url}
+[GitHub Discussions]: ${github_discussions_url}
 
 ## Hacking on `${repo}`
 
@@ -108,13 +112,19 @@ if __name__ == "__main__":
         "--org-contrib-url",
         default=DEFAULT_ORG_CONTRIBUTING_URL,
         type=str,
-        help="link to org-level contrib file",
+        help="override link to org-level contrib file",
     )
     parser.add_argument(
         "--matrix-url",
         default=DEFAULT_MATRIX_URL,
         type=str,
-        help="link to the ubuntu hpc matrix",
+        help="override link to the ubuntu hpc matrix",
+    )
+    parser.add_argument(
+        "--github-discussions-url",
+        default=DEFAULT_GITHUB_DISCUSSIONS_URL,
+        type=str,
+        help="override link github discussions",
     )
     parser.add_argument(
         "--repo-contrib",
@@ -186,9 +196,10 @@ if __name__ == "__main__":
             current_year=datetime.now().year,
             org_contrib_url=args.org_contrib_url,
             matrix_url=args.matrix_url,
+            github_discussions_url=args.github_discussions_url,
             repo_contrib=args.repo_contrib or "",
             before_pr_contrib=args.before_pr_contrib or "",
             additional_license_info=args.additional_license_info or "",
         ),
-        file=open(args.output, "wt") or sys.stdout,
+        file=open(args.output, "wt") if args.output else sys.stdout,
     )

--- a/scripts/gen-contrib
+++ b/scripts/gen-contrib
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate per-repository CONTRIBUTING.md files."""
+
+import argparse
+import json
+import sys
+import textwrap
+from datetime import datetime
+from string import Template
+from urllib.request import urlopen
+
+DEFAULT_ORG_CONTRIBUTING_URL = (
+    "https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md"
+)
+DEFAULT_MATRIX_URL = "https://matrix.to/#/#hpc:ubuntu.com"
+LICENSES = {
+    "agpl-3.0-only": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/AGPL-3.0-only.json",
+    "apache-2.0": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/Apache-2.0.json",
+    "gpl-3.0-only": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/GPL-3.0-only.json",
+    "lgpl-3.0-only": "https://github.com/spdx/license-list-data/raw/refs/heads/main/json/details/LGPL-3.0-only.json",
+}
+
+CONTRIBUTING_TEMPLATE = """
+# Contributing to `${repo}`
+
+Do you want to contribute to the `${repo}` repository? You've come to the right place then!
+__Here is how you can get involved.__
+
+Before you start working on your contribution, please familiarize yourself with the [Charmed
+HPC project's contributing guide]. Come back here after you've gone through
+the main contributing guide for specific information on contributing to the
+`${repo}` repository.
+
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
+
+[Charmed HPC project's contributing guide]: ${org_contrib_url}
+[Ubuntu High-Performance Computing Matrix chat]: ${matrix_url}
+
+## Hacking on `${repo}`
+
+${repo_contrib}
+
+### Before opening a pull request on the `${repo}` repository
+
+Ensure that your changes pass all the existing tests, and that you have added tests
+for any new features you're introducing in this changeset.
+
+${before_pr_contrib}
+
+## License information
+
+By contributing to `${repo}`, you agree to license your contribution under
+the ${license_name} license.
+
+${additional_license_info}
+
+### Adding a new file to `${repo}`
+
+If you add a new source code file to the repository, add the following license header
+as a comment to the top of the file with the copyright owner set to the organization
+you are contributing on behalf of and the current year set as the copyright year.
+
+```text
+${license_header}
+```
+
+### Updating an existing file in `${repo}`
+
+If you are making changes to an existing file, and the copyright year is not the current year,
+update the year range to include the current year. For example, if a file's copyright year is:
+
+```text
+Copyright 2023 Canonical Ltd.
+```
+
+and you make changes to that file in ${current_year}, update the copyright year in the file to:
+
+```text
+Copyright 2023-${current_year} Canonical Ltd.
+```
+""".lstrip()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="gen-contrib")
+    parser.add_argument(
+        "-r", "--repo", type=str, required=True, help="name of the repository"
+    )
+    parser.add_argument("--license", type=str, required=True, help="repository license")
+    parser.add_argument("-o", "--output", type=str, default=None, help="output file")
+
+    # Optional overrides
+    parser.add_argument(
+        "--org-contrib-url",
+        default=DEFAULT_ORG_CONTRIBUTING_URL,
+        type=str,
+        help="link to org-level contrib file",
+    )
+    parser.add_argument(
+        "--matrix-url",
+        default=DEFAULT_MATRIX_URL,
+        type=str,
+        help="link to the ubuntu hpc matrix",
+    )
+    parser.add_argument(
+        "--repo-contrib",
+        type=str,
+        help="additional contribution information for the repository",
+    )
+    parser.add_argument(
+        "--before-pr-contrib",
+        type=str,
+        help="additional contribution information for before opening a pr",
+    )
+    parser.add_argument(
+        "--additional-license-info",
+        action="store",
+        help="repository license information",
+    )
+
+    args = parser.parse_args()
+
+    if args.license not in LICENSES:
+        sys.stderr.write(
+            (
+                f"invalid license option '{args.license}'. "
+                + "valid options are {}\n".format(
+                    ", ".join(f"'{opt}'" for opt in LICENSES)
+                )
+            )
+        )
+        raise SystemExit(1)
+
+    with urlopen(LICENSES[args.license]) as response:
+        license_data = json.loads(response.read().decode("utf-8"))
+
+        # LGPL-3.0-only does not define a standard license header format,
+        # so declare one ourselves.
+        if args.license == "lgpl-3.0-only":
+            license_data["standardLicenseHeader"] = textwrap.dedent(
+                """
+                Copyright (C) [year] [name of author]
+
+                This program is free software; you can redistribute it and/or
+                modify it under the terms of the GNU Lesser General Public
+                License version 3 as published by the Free Software Foundation.
+
+                This program is distributed in the hope that it will be useful,
+                but WITHOUT ANY WARRANTY; without even the implied warranty of
+                MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+                Lesser General Public License for more details.
+
+                You should have received a copy of the GNU Lesser General Public License
+                along with this program.  If not, see <http://www.gnu.org/licenses/>.
+                """
+            )
+
+        # Format the GPL licenses so that they look nice in the generated CONTRIBUTING.md.
+        if args.license in ["agpl-3.0-only", "gpl-3.0-only"]:
+            header, body = license_data["standardLicenseHeader"].split("\n", maxsplit=1)
+            body = [f"{header}\n\n"] + [
+                f"{textwrap.fill(stanza, width=75)}\n\n"
+                for stanza in body.split("\n\n")
+            ]
+            license_data["standardLicenseHeader"] = "".join(body)
+
+    print(
+        Template(CONTRIBUTING_TEMPLATE).substitute(
+            repo=args.repo,
+            license_name=license_data["name"],
+            license_header=license_data["standardLicenseHeader"].strip(),
+            current_year=datetime.now().year,
+            org_contrib_url=args.org_contrib_url,
+            matrix_url=args.matrix_url,
+            repo_contrib=args.repo_contrib or "",
+            before_pr_contrib=args.before_pr_contrib or "",
+            additional_license_info=args.additional_license_info or "",
+        ),
+        file=open(args.output, "wt") or sys.stdout,
+    )


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds the `gen-contrib` script for quickly generating per-repo CONTRIBUTING.md documents. To generate a simple project CONTRIBUTING.md document, all you need to do is run the following command:

```shell
./gen-contrib --repo slurm-charms --license apache-2.0
```

To add further information such as general contributing information, or steps that you need to follow before opening a new PR on the repository, you can pass additional content via the command-line:

```shell
./gen-contrib --repo slurm-charms --license apache-2.0 --before-pr-contrib "$(cat just-instructions.md)" --repo-contrib "$(cat subpackage-howto.md)"
```

To save the CONTRIBUTING.md file generated by `gen-contrib`, you can either redirect the _stdout_ of the script to a file, or pass the `--output` flag:

```shell
./gen-contrib --repo slurm-charms --license apache-2.0 > CONTRIBUTING.md
```

or

```shell
./gen-contrib --repo slurm-charms --license apache-2.0 --output CONTRIBUTING.md
```

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This script is related to our ongoing work to update our community documentation. After this PR is merged, the script will be used to update our repositorys' CONTRIBUTING.md files to point to the organization-wide CONTRIBUTING.md file.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This script does not introduce a user facing change, and is primarily meant to be used by Charmed HPC project developers for quickly creating new CONTRIBUTING.md documents.