### PR TITLE
feat: common CI workflow

### DIFF
--- a/.github/actions/setup-just/action.yaml
+++ b/.github/actions/setup-just/action.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Setup just
+description: Install a pinned version of just
+
+inputs:
+  just-version:
+    description: Override the pinned just version
+    required: false
+    default: "1.48.1"
+
+runs:
+  using: composite
+  steps:
+    - uses: extractions/setup-just@v4
+      with:
+        just-version: ${{ inputs.just-version }}

--- a/.github/actions/setup-just/action.yaml
+++ b/.github/actions/setup-just/action.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 name: Setup just
 description: Install a pinned version of just
 

--- a/.github/workflows/charmed-hpc-ci.yaml
+++ b/.github/workflows/charmed-hpc-ci.yaml
@@ -1,0 +1,80 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+on:
+  workflow_call:
+    inputs:
+      setup-commands:
+        description: Commands to install repo-specific tools
+        type: string
+        default: ""
+      run-test:
+        type: boolean
+        default: true
+
+jobs:
+  inclusive-naming-check:
+    name: Inclusive naming check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+
+  commitlint:
+    name: Commit lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install -D @commitlint/cli @commitlint/config-conventional
+      - run: |
+          if [ ! -f .commitlintrc.yml ]; then
+            echo "extends: ['@commitlint/config-conventional']" > .commitlintrc.yml
+          fi
+      - run: >-
+          npx commitlint
+          --from ${{ github.event.pull_request.base.sha }}
+          --to ${{ github.event.pull_request.head.sha }}
+          --verbose
+
+  check:
+    name: Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: charmed-hpc/.github/.github/actions/setup-just@main
+      - if: inputs.setup-commands != ''
+        run: ${{ inputs.setup-commands }}
+      - run: just check
+
+  test:
+    name: Test
+    if: ${{ inputs.run-test }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: charmed-hpc/.github/.github/actions/setup-just@main
+      - if: inputs.setup-commands != ''
+        run: ${{ inputs.setup-commands }}
+      - run: just test

--- a/.github/workflows/charmed-hpc-ci.yaml
+++ b/.github/workflows/charmed-hpc-ci.yaml
@@ -52,11 +52,11 @@ jobs:
           if [ ! -f .commitlintrc.yml ]; then
             echo "extends: ['@commitlint/config-conventional']" > .commitlintrc.yml
           fi
-      - run: >-
-          npx commitlint
-          --from ${{ github.event.pull_request.base.sha }}
-          --to ${{ github.event.pull_request.head.sha }}
-          --verbose
+      - run: |
+          npx commitlint \
+            --from ${{ github.event.pull_request.base.sha }} \
+            --to ${{ github.event.pull_request.head.sha }} \
+            --verbose
 
   check:
     name: Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,47 +18,8 @@ on:
   pull_request:
 
 jobs:
-  inclusive-naming-check:
-    name: Inclusive naming check
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run tests
-        uses: get-woke/woke-action@v0
-        with:
-          fail-on-error: true
-
-  validation:
-    name: Validate Terraform plans
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install `opentofu`
-        run: sudo snap install opentofu --classic
-      - name: Install `just`
-        uses: extractions/setup-just@v2
-        with:
-          just-version: 1.38.0
-      - name: Run validation tests
-        run: just validate
-
-  commitlint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - name: Install commitlint
-        run: npm install -D @commitlint/cli @commitlint/config-conventional
-      - name: Validate PR commits with commitlint
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+  ci:
+    uses: ./.github/workflows/charmed-hpc-ci.yaml
+    with:
+      run-test: false
+      setup-commands: sudo snap install opentofu --classic --channel latest/stable

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env just --justfile
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,21 +23,28 @@ default_plan_list := shell("ls -d -- $1/*", terraform_dir)
 default:
     @just help
 
-# Apply formatting standards to project
-[group("dev")]
-fmt:
-    just --fmt --unstable
-    tofu fmt -recursive
+# Prepare the local environment
+setup: init
 
 # Clean project directory
-[group("dev")]
 clean:
     find . -name .terraform -type d | xargs rm -rf
     find . -name .terraform.lock.hcl -type f | xargs rm -rf
     find . -name "terraform.tfstate*" -type f | xargs rm -rf
 
+# Apply static checks
+check: fmt validate
+
+# Run tests for specified targets, or all tests if none specified
+test *targets:
+    @echo "No tests to run"
+
+# Apply formatting standards to project
+fmt:
+    just --fmt --unstable
+    tofu fmt -recursive
+
 # Initialize Terraform plans
-[group("terraform")]
 init *plans:
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -47,7 +54,6 @@ init *plans:
     done
 
 # Validate Terraform plans
-[group("terraform")]
 validate *plans: (init plans)
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -58,7 +64,6 @@ validate *plans: (init plans)
     done
 
 # Apply Terraform plans
-[group("terraform")]
 apply *plans: (validate plans)
     #!/usr/bin/env bash
     set -euxo pipefail


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This repo `justfile` now implements [UHPC011](https://github.com/charmed-hpc/specs/blob/7d26b85/specs/UHPC%20011%20-%20Common%20justfile%20format%20for%20Charmed%20HPC%20repositories/uhpc011.md):
* New `check` recipe performs `fmt validate`
* New `test` recipe is a no-op

A new `setup-just` action is added that installs just v1.48.1:
* Standard method for all Charmed HPC repos to install just
* Replaces mix of `snap install just` and `extractions/setup-just@v4` in repo CIs
* Pinned to the just version in UHPC011. Updating this applies the change across the org
* Pinned version can be overridden by the repo if necessary

A new `charmed-hpc-ci` workflow added for use by all Charmed HPC org repos.
* Runs common jobs: `inclusive-naming-check`, `commitlint`, `check`
* Provides a default `.commitlintrc.yml`
  * This file no longer needs to be duplicated per repo but including one in the repo overrides the default
* `check` runs `just check`, guaranteed to be present if repo `justfile` follows UHPC011
* `test` job runs `just test`. Can be disabled with `run-test: false` for repos that require more control over tests, e.g. charms with separate unit and integration tests.
* `setup-commands` input used to define installation commands for repo-specific tools, e.g. opentofu, uv, charmcraft.

With this, the CI for this repo becomes:

```yaml
name: CI
on:
  workflow_call:
  pull_request:

jobs:
  ci:
    uses: ./.github/workflows/charmed-hpc-ci.yaml
    with:
      run-test: false
      setup-commands: sudo snap install opentofu --classic --channel latest/stable
```

Expected CI changes for org repos (collapsible blocks):

<details>

<summary>slurmutils</summary>

```yaml
name: CI
on:
  workflow_call:
  pull_request:

jobs:
  ci:
    uses: charmed-hpc/.github/.github/workflows/charmed-hpc-ci.yaml@main
    with:
      setup-commands: sudo snap install astral-uv --classic --channel latest/stable
```

</details>

<details>

<summary>sssd-operator</summary>

YAML anchor `&setup_cmds` used to avoid repetition.

```yaml
name: CI
on:
  workflow_call:
  pull_request:

jobs:
  ci:
    uses: charmed-hpc/.github/.github/workflows/charmed-hpc-ci.yaml@main
    with:
      run-test: false
      setup-commands: &setup_cmds |
        sudo snap install astral-uv --classic --channel latest/stable
        sudo snap install charmcraft --classic --channel latest/stable

  unit-test:
    name: Unit tests
    runs-on: ubuntu-24.04
    steps:
      - uses: actions/checkout@v4
      - uses: charmed-hpc/.github/.github/actions/setup-just@main
      - run: *setup_cmds
      - run: just test unit

  integration-test:
    name: Integration tests (LXD)
    runs-on: ubuntu-24.04
    needs: [ci, unit-test]
    steps:
      - uses: actions/checkout@v4
      - uses: charmed-hpc/.github/.github/actions/setup-just@main
      - run: *setup_cmds
      - uses: charmed-kubernetes/actions-operator@main
        with:
          provider: lxd
          juju-channel: 3.6/stable
      - run: just test integration
```

</details>

<details>

<summary>slurm-charms</summary>

```yaml
name: CI
on:
  workflow_call:
    inputs:
      enable_ha:
        description: "Enable High Availability tests"
        type: boolean
        default: false
  pull_request:
    branches: [main, experimental]
  schedule:
    - cron: '0 3 * * *'  # 03:00 UTC nightly

concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true

jobs:
  ci:
    uses: charmed-hpc/.github/.github/workflows/charmed-hpc-ci.yaml@main
    with:
      run-test: false
      setup-commands: &setup_cmds |
        sudo snap install astral-uv --classic --channel latest/stable
        sudo snap install charmcraft --classic --channel latest/stable

  unit-test:
    name: Unit tests
    runs-on: ubuntu-24.04
    steps:
      - uses: actions/checkout@v4
      - uses: charmed-hpc/.github/.github/actions/setup-just@main
      - run: *setup_cmds
      - run: just test unit

  integration-test:
    name: Integration tests (LXD) | ${{ matrix.bases }}
    needs: [ci, unit-test]
    strategy:
      fail-fast: true
      matrix:
        bases: [ubuntu@24.04]
    # xlarge runner used for nightly and HA-enabled tests. Standard ubuntu runner otherwise
    runs-on: ${{ (github.event_name == 'schedule' || inputs.enable_ha) && 'self-hosted-linux-amd64-noble-xlarge' || 'ubuntu-24.04' }}
    steps:
      - name: Remove unnecessary files
        run: |
          # Remove Java SDKs
          sudo rm -rf /usr/lib/jvm

          # Remove Haskell toolchain
          sudo rm -rf /opt/ghc
          sudo rm -rf /usr/local/.ghcup

          # Remove .NET SDKs
          sudo rm -rf /usr/share/dotnet

          # Remove Swift toolchain
          sudo rm -rf /usr/share/swift

          # Remove unnecessary runner tools
          sudo rm -rf /usr/local/share/boost
          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
      - uses: actions/checkout@v4
      - uses: charmed-hpc/.github/.github/actions/setup-just@main
      - run: *setup_cmds
      - uses: charmed-kubernetes/actions-operator@main
        with:
          provider: lxd
          juju-channel: 3.6/stable
      - name: Run tests
        run: |
          declare -a ARGS=()
          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.enable_ha }}" == "true" ]]; then
            ARGS+=("--run-high-availability")
          fi
          just integration -- --charm-base=${{ matrix.bases }} ${ARGS[*]}
```

</details>

Future work: charm repos have a common pattern of unit and integration tests that require similar setup, e.g. `charmed-kubernetes/actions-operator@main`. Generalizing this could be a goal for a future PR.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is necessary to standardize the installation of `just` across the org and de-duplicate CI workflows.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Not a user-facing change - no docs PR required.